### PR TITLE
Tweaks to comments to fix generation problems with RTD

### DIFF
--- a/docs/source/von_anchor_demo.rst
+++ b/docs/source/von_anchor_demo.rst
@@ -1,3 +1,6 @@
+von\_anchor\_demo package
+=========================
+
 .. automodule:: von_anchor.anchor.demo
     :members:
     :undoc-members:

--- a/docs/source/von_anchor_roles.rst
+++ b/docs/source/von_anchor_roles.rst
@@ -29,7 +29,7 @@ von\_anchor.anchor.origin module
     :show-inheritance:
 
 von\_anchor.anchor.rrbuilder module
---------------------------------
+-----------------------------------
 
 .. automodule:: von_anchor.anchor.rrbuilder
     :members:
@@ -45,7 +45,7 @@ von\_anchor.anchor.issuer module
     :show-inheritance:
 
 von\_anchor.anchor.holderprover module
-----------------------------------------
+--------------------------------------
 
 .. automodule:: von_anchor.anchor.holderprover
     :members:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,5 +4,5 @@ build:
   image: latest
 
 python:
-  version: 3.5
+  version: 3.6
   setup_py_install: true

--- a/von_anchor/anchor/holderprover.py
+++ b/von_anchor/anchor/holderprover.py
@@ -665,9 +665,10 @@ class HolderProver(_BaseAnchor):
         """
         Return json object on lists of all unique box identifiers for credentials in wallet, as
         evidenced by tails directory content:
-          * schema identifiers
-          * credential definition identifiers
-          * revocation registry identifiers.
+
+        * schema identifiers
+        * credential definition identifiers
+        * revocation registry identifiers.
 
         E.g.,
 
@@ -834,6 +835,7 @@ class HolderProver(_BaseAnchor):
         :return: credential infos as json list; i.e.,
 
         ::
+
             [
                 {
                     "referent": string,  # credential identifier in the wallet
@@ -1111,6 +1113,7 @@ class HolderProver(_BaseAnchor):
             referents; e.g.,
 
         ::
+        
             {
                 "17_thing_uuid": { # require attr presence on name 'thing', cred def id from proof req above
                     "$or": [
@@ -1128,6 +1131,7 @@ class HolderProver(_BaseAnchor):
             e.g.,
 
         ::
+
             (
                 {
                     'b42ce5bc-b690-43cd-9493-6fe86ad25e85',
@@ -1164,6 +1168,7 @@ class HolderProver(_BaseAnchor):
                     }
                 ]'
             }
+        
         """
 
         LOGGER.debug(

--- a/von_anchor/codec.py
+++ b/von_anchor/codec.py
@@ -97,7 +97,7 @@ def canon_wql(query: dict) -> dict:
     Raise BadWalletQuery for WQL mapping '$or' to non-list.
 
     :param query: WQL query
-    :return canonicalized WQL query dict
+    :return: canonicalized WQL query dict
     """
 
     for k in query:

--- a/von_anchor/util.py
+++ b/von_anchor/util.py
@@ -254,6 +254,7 @@ def proof_req_infos2briefs(proof_req: dict, infos: Union[dict, tuple, list]) -> 
     :param infos: cred-info, or list/tuple thereof; e.g.,
 
     ::
+    
         [
             {
                 'attrs': {
@@ -312,6 +313,7 @@ def proof_req_briefs2req_creds(proof_req: dict, briefs: Union[dict, tuple, list]
     :param briefs: credential brief or list/tuple thereof, as indy-sdk wallet credential search returns; e.g.,
 
     ::
+
         [
             {
                 "cred_info": {


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

Minor tweaks to the comments used to generate the RTD documents, but ones that prevented the display of the code.  Please push these fixes through as soon as possible so that we have good docs online - currently they are blank.  I didn't realize just how fragile these where - a small mistake prevents large chunks/all of the documentation from being produced.

Code related problems:

- bad indent of a list (no need to indent a bullet list)
- a ":" missing after "return"
- Missing blank line between "::" indicator and JSON
- Missing blank line between end of JSON and the """ indicator

Thanks
